### PR TITLE
Circle 2.0 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/circuitry-middleware
+    docker:
+      - image: kapost/ruby:2.4.3-node-6.11.5
+    steps:
+      - checkout
+      - run: bundle install
+      - run:
+          name: Rspec
+          command: bundle exec rspec --format documentation --color spec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,5 +8,13 @@ jobs:
       - checkout
       - run: bundle install
       - run:
+          name: install cc-test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+            ./cc-test-reporter before-build
+      - run:
           name: Rspec
-          command: bundle exec rspec --format documentation --color spec
+          command: |
+            bundle exec rspec --format documentation --color spec
+            ./cc-test-reporter after-build --exit-code $?

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-machine:
-  ruby:
-    version: 2.2.0
-
-dependencies:
-  pre:
-    - gem install bundler -v 1.8.9

--- a/circuitry-middleware.gemspec
+++ b/circuitry-middleware.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.2'
-  spec.add_development_dependency 'codeclimate-test-reporter'
+  spec.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'circuitry/middleware'


### PR DESCRIPTION
Circle is sunsetting 1.0 configs and builds effective August 31, 2018. This gets circuitry-middleware on circle 2.0.

Also, although the [codeclimate-test-reporter gem](https://github.com/codeclimate/ruby-test-reporter) has been deprecated for some time now, it is now _officially_ deprecated and failing builds:
![screen shot 2018-07-05 at 2 45 05 pm](https://user-images.githubusercontent.com/8997552/42347100-09d7d2de-8062-11e8-89da-2f14d913d65b.png)
